### PR TITLE
Store downloaded files from s3 in /tmp

### DIFF
--- a/printer/PrintHandler.js
+++ b/printer/PrintHandler.js
@@ -35,7 +35,7 @@ setInterval(() => {
 
     const orderData = JSON.parse(data.Messages[0].Body);
     const {fileNo} = orderData;
-    const path = `/tmp/${fileNo}.pdf`; 
+    const path = `/tmp/${fileNo}.pdf`;
 
     const paramers = {
       Bucket: PRINTING_BUCKET_NAME,

--- a/printer/PrintHandler.js
+++ b/printer/PrintHandler.js
@@ -35,7 +35,7 @@ setInterval(() => {
 
     const orderData = JSON.parse(data.Messages[0].Body);
     const {fileNo} = orderData;
-    const path = `./${fileNo}.pdf`;
+    const path = `/tmp/${fileNo}.pdf`; 
 
     const paramers = {
       Bucket: PRINTING_BUCKET_NAME,


### PR DESCRIPTION
We were previously using a relative path for storing user's files to be printed. Using /tmp has them automatically deleted after 10 days or on a reboot.

For more info on the `/tmp` dir, see this:
[link](https://www.fosslinux.com/41739/linux-tmp-directory-everything-you-need-to-know.htm)