### PR TITLE
Delete print request from SQS on successful print

### DIFF
--- a/printer/PrintHandler.js
+++ b/printer/PrintHandler.js
@@ -35,7 +35,7 @@ setInterval(() => {
 
     const orderData = JSON.parse(data.Messages[0].Body);
     const {fileNo} = orderData;
-    const path = `/tmp/${fileNo}.pdf`; 
+    const path = `/tmp/${fileNo}.pdf`;
 
     const paramers = {
       Bucket: PRINTING_BUCKET_NAME,

--- a/printer/PrintHandler.js
+++ b/printer/PrintHandler.js
@@ -45,25 +45,22 @@ setInterval(() => {
     s3.getObject(paramers, (err, data) => {
       if (err) console.error(err);
       fs.writeFileSync(path, data.Body, 'binary');
-    });
-
-    exec(
-      'sudo lp -n 1 -o sides=one-sided -d ' +
+      exec(
+        'sudo lp -n 1 -o sides=one-sided -d ' +
         `HP-LaserJet-p2015dn-right ${path}`,
-      (error, stdout, stderr) => {
-        if (error) throw error;
-        if (stderr) throw stderr;
-        if (error) exec(`rm ${path}`, () => { });
-      }
-    );
+        (error, stdout, stderr) => {
+          if (error) throw error;
+          if (stderr) throw stderr;
+          exec(`rm ${path}`, () => { });
+          const deleteParams = {
+            QueueUrl: queueUrl,
+            ReceiptHandle: data.Messages[0].ReceiptHandle,
+          };
 
-    const deleteParams = {
-      QueueUrl: queueUrl,
-      ReceiptHandle: data.Messages[0].ReceiptHandle,
-    };
-
-    sqs.deleteMessage(deleteParams, (err) => {
-      if (err) throw err;
+          sqs.deleteMessage(deleteParams, (err) => {
+            if (err) throw err;
+          });
+        });
     });
   });
 }, 10000);

--- a/printer/PrintHandler.js
+++ b/printer/PrintHandler.js
@@ -35,7 +35,7 @@ setInterval(() => {
 
     const orderData = JSON.parse(data.Messages[0].Body);
     const {fileNo} = orderData;
-    const path = `./${fileNo}.pdf`;
+    const path = `/tmp/${fileNo}.pdf`; 
 
     const paramers = {
       Bucket: PRINTING_BUCKET_NAME,


### PR DESCRIPTION
### Merge #11 first!

Part of https://github.com/SCE-Development/Quasar/issues/4. `s3.getObject` was being ran independently before printing/deleting
the SQS message. By placing the printing and SQS logic from within the s3
callback, the correct flow is achieved:

1. download the file from s3
1. write the file to `/tmp` with `writeFileSync`
1. send the request to the printer
1. if no error occurred with printing, delete the file from disk and sqs
message.
