### PR TITLE
Change AWS region for LED queue

### DIFF
--- a/ledsign/LEDSignHandler.js
+++ b/ledsign/LEDSignHandler.js
@@ -11,7 +11,7 @@ AWS.config.update({
 });
 
 const sqs = new AWS.SQS({ apiVersion: '2012-11-05' });
-const queueUrl = `https://sqs.us-west-1.amazonaws.com/${ACCOUNT_ID}/${LED_QUEUE_NAME}`;
+const queueUrl = `https://sqs.us-west-2.amazonaws.com/${ACCOUNT_ID}/${LED_QUEUE_NAME}`;
 
 const params = {
   QueueUrl: queueUrl,


### PR DESCRIPTION
In [`Core-v4/api/peripheral_api/routes/LedSign.js:18`](https://github.com/SCE-Development/Core-v4/blob/5c8e67f40760abb1b59724d113ef8a5387bd90a0/api/peripheral_api/routes/LedSign.js#L18) we are pushing led sign requests to a queue in the Oregon (`us-west-2`) AWS region. So it makes sense read from same region no?