### PR TITLE
util folder now copied into containers for ledsign and printer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       dockerfile: ./ledsign/Dockerfile
     networks:
       - quasar-local
-    volumes:
-      - ./util:/app/util:ro
   sce-printer:
     container_name: sce-printer
     build:
@@ -25,7 +23,6 @@ services:
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
     volumes:
       - '/etc/cups/ppd/:/etc/cups/ppd'
-      - ./util:/app/util:ro
     networks:
       - quasar-local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
     volumes:
-      - '/etc/cups/ppd/:/etc/cups/ppd'
+      - "/etc/cups/ppd/:/etc/cups/ppd"
     networks:
       - quasar-local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: ./ledsign/Dockerfile
     networks:
       - quasar-local
+    volumes:
+      - ./util:/app/util:ro
   sce-printer:
     container_name: sce-printer
     build:
@@ -22,7 +24,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
     volumes:
-      - "/etc/cups/ppd/:/etc/cups/ppd"
+      - '/etc/cups/ppd/:/etc/cups/ppd'
+      - ./util:/app/util:ro
     networks:
       - quasar-local
 

--- a/ledsign/Dockerfile
+++ b/ledsign/Dockerfile
@@ -15,4 +15,6 @@ COPY ./ledsign /app/ledsign
 
 COPY ./config/config.json /app/config/config.json
 
+COPY /util /app/util
+
 CMD [ "node", "./ledsign/LEDSignHandler.js" ]

--- a/printer/Dockerfile
+++ b/printer/Dockerfile
@@ -29,6 +29,8 @@ COPY ./config/config.json /app/config/config.json
 
 COPY ./printer /app/printer
 
+COPY /util /app/util
+
 # The below command runs the bash script that sets up the connection to the
 # printers and runs PrintHandler.js
 ENTRYPOINT [ "./printer/what.sh" ]


### PR DESCRIPTION
util/SqsMessageHandler.js wasn't being copied in the docker-compose.yml, so attempting to build was causing an error with sce-printer and sce-ledsign. With this fix both are building again.