### PR TITLE
fix sqs message parse

### DIFF
--- a/util/SqsMessageHandler.js
+++ b/util/SqsMessageHandler.js
@@ -14,8 +14,8 @@ function readMessageFromSqs(params, sqs) {
           return resolve(false);
         }
         const data = {
-          Body: JSON.parse(printRequestFromSqs.Message[0].Body),
-          ReceiptHandle: JSON.parse(printRequestFromSqs.Message[0].ReceiptHandle)
+          Body: JSON.parse(printRequestFromSqs.Messages[0].Body),
+          ReceiptHandle: printRequestFromSqs.Messages[0].ReceiptHandle
         };
         return resolve(data);
       });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/80026779/172083935-5622eb28-f9b7-4853-9898-ecc2ab0a9c51.png)

I fixed the bug above by renaming the message to messages and deleting the JSON parse in the receipt handle, I've tested these locally and it worked.