### PR TITLE
bump LED-Sign node version to 14

### DIFF
--- a/ledsign/Dockerfile
+++ b/ledsign/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.10.0-alpine 
+FROM node:14.10.0-alpine 
 #gets the base linux image
 
 WORKDIR /app


### PR DESCRIPTION
bump LED-Sign node version to 14, there was an error with the file we were using because node version was not update. 