### PR TITLE
Add Logging to Quasar

### DIFF
--- a/util/logger.js
+++ b/util/logger.js
@@ -1,0 +1,60 @@
+const consoleColors = {
+    red: '\x1b[31m',
+    green: '\x1b[32m',
+    blue: '\x1b[34m',
+    yellow: '\x1b[33m',
+    default: '\x1b[0m',
+  };
+  
+  const LOG_LEVELS = {
+    DEBUG: 'DEBUG',
+    INFO: 'INFO',
+    WARNING: 'WARNING',
+    ERROR: 'ERROR',
+  };
+  
+  function getLineOfCode() {
+    const e = new Error();
+    // point out that 2 is for parent, 3 for grandparent etc...
+    // yields "at Object.<anonymous> (/path/to/file.js:7:1)"
+    const parentFunc = e.stack.split("\n")[4];
+    const fileAndLineOfCode = parentFunc
+      .split("/") // yields "file.js:7:1)"
+      .reverse()[0] // yields "file.js:7:1"
+      .split(")")[0]; // yields "file.js:7:1"
+    return fileAndLineOfCode;
+  }
+  
+  // Do not call this function directly! Use the below factory
+  // functions instead
+  function printToConsole(level, message) {
+    let formattedMessage = new Date().toISOString()
+    formattedMessage += ` ${getLineOfCode()}`
+    formattedMessage += ` ${level}`
+    formattedMessage += ` ${message}`
+    // Print the log as red or green if the level is error or warning
+    if (level === LOG_LEVELS.ERROR) {
+      formattedMessage = `${consoleColors.red}${formattedMessage}${consoleColors.default}`
+    } else if (level === LOG_LEVELS.WARNING) {
+      formattedMessage = `${consoleColors.yellow}${formattedMessage}${consoleColors.default}`
+    }
+    console.log(formattedMessage)
+  }
+  
+  function debug(message) {
+    printToConsole(LOG_LEVELS.DEBUG, message);
+  }
+  
+  function info(message) {
+    printToConsole(LOG_LEVELS.INFO, message);
+  }
+  
+  function warn(message) {
+    printToConsole(LOG_LEVELS.WARNING, `${message}`);
+  }
+  
+  function error(message) {
+    printToConsole(LOG_LEVELS.ERROR, `${message}`);
+  }
+  
+  module.exports = { debug, info, warn, error };

--- a/util/logger.js
+++ b/util/logger.js
@@ -1,60 +1,60 @@
 const consoleColors = {
-    red: '\x1b[31m',
-    green: '\x1b[32m',
-    blue: '\x1b[34m',
-    yellow: '\x1b[33m',
-    default: '\x1b[0m',
-  };
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  blue: '\x1b[34m',
+  yellow: '\x1b[33m',
+  default: '\x1b[0m',
+};
   
-  const LOG_LEVELS = {
-    DEBUG: 'DEBUG',
-    INFO: 'INFO',
-    WARNING: 'WARNING',
-    ERROR: 'ERROR',
-  };
+const LOG_LEVELS = {
+  DEBUG: 'DEBUG',
+  INFO: 'INFO',
+  WARNING: 'WARNING',
+  ERROR: 'ERROR',
+};
   
-  function getLineOfCode() {
-    const e = new Error();
-    // point out that 2 is for parent, 3 for grandparent etc...
-    // yields "at Object.<anonymous> (/path/to/file.js:7:1)"
-    const parentFunc = e.stack.split("\n")[4];
-    const fileAndLineOfCode = parentFunc
-      .split("/") // yields "file.js:7:1)"
-      .reverse()[0] // yields "file.js:7:1"
-      .split(")")[0]; // yields "file.js:7:1"
-    return fileAndLineOfCode;
+function getLineOfCode() {
+  const e = new Error();
+  // point out that 2 is for parent, 3 for grandparent etc...
+  // yields "at Object.<anonymous> (/path/to/file.js:7:1)"
+  const parentFunc = e.stack.split('\n')[4];
+  const fileAndLineOfCode = parentFunc
+    .split('/') // yields "file.js:7:1)"
+    .reverse()[0] // yields "file.js:7:1"
+    .split(')')[0]; // yields "file.js:7:1"
+  return fileAndLineOfCode;
+}
+  
+// Do not call this function directly! Use the below factory
+// functions instead
+function printToConsole(level, message) {
+  let formattedMessage = new Date().toISOString();
+  formattedMessage += ` ${getLineOfCode()}`;
+  formattedMessage += ` ${level}`;
+  formattedMessage += ` ${message}`;
+  // Print the log as red or green if the level is error or warning
+  if (level === LOG_LEVELS.ERROR) {
+    formattedMessage = `${consoleColors.red}${formattedMessage}${consoleColors.default}`;
+  } else if (level === LOG_LEVELS.WARNING) {
+    formattedMessage = `${consoleColors.yellow}${formattedMessage}${consoleColors.default}`;
   }
+  console.log(formattedMessage);
+}
   
-  // Do not call this function directly! Use the below factory
-  // functions instead
-  function printToConsole(level, message) {
-    let formattedMessage = new Date().toISOString()
-    formattedMessage += ` ${getLineOfCode()}`
-    formattedMessage += ` ${level}`
-    formattedMessage += ` ${message}`
-    // Print the log as red or green if the level is error or warning
-    if (level === LOG_LEVELS.ERROR) {
-      formattedMessage = `${consoleColors.red}${formattedMessage}${consoleColors.default}`
-    } else if (level === LOG_LEVELS.WARNING) {
-      formattedMessage = `${consoleColors.yellow}${formattedMessage}${consoleColors.default}`
-    }
-    console.log(formattedMessage)
-  }
+function debug(message) {
+  printToConsole(LOG_LEVELS.DEBUG, message);
+}
   
-  function debug(message) {
-    printToConsole(LOG_LEVELS.DEBUG, message);
-  }
+function info(message) {
+  printToConsole(LOG_LEVELS.INFO, message);
+}
   
-  function info(message) {
-    printToConsole(LOG_LEVELS.INFO, message);
-  }
+function warn(message) {
+  printToConsole(LOG_LEVELS.WARNING, `${message}`);
+}
   
-  function warn(message) {
-    printToConsole(LOG_LEVELS.WARNING, `${message}`);
-  }
+function error(message) {
+  printToConsole(LOG_LEVELS.ERROR, `${message}`);
+}
   
-  function error(message) {
-    printToConsole(LOG_LEVELS.ERROR, `${message}`);
-  }
-  
-  module.exports = { debug, info, warn, error };
+module.exports = { debug, info, warn, error };


### PR DESCRIPTION
resolves #18 
resolves #32

Example usage:
```js
const logger = require('./util/logger')


logger.info("This is info")
logger.debug("This is debug")
logger.warn("This is a warning")
logger.error("I am an error!")
```
<img width="434" alt="Screen Shot 2022-06-26 at 8 46 04 PM" src="https://user-images.githubusercontent.com/63530023/175856199-7302afeb-1ec7-4e6b-bde7-529908a7ed80.png">

