### PR TITLE
Add Prometheus alerts for container not running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - sce-printer
   nginx:
     image: 'nginx'
-    container_name: arcam_nginx
+    container_name: quasar_nginx
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     command: [nginx-debug, '-g', 'daemon off;']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/prometheus/:/etc/prometheus:ro
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     depends_on:

--- a/monitoring/prometheus/alert_rules.yml
+++ b/monitoring/prometheus/alert_rules.yml
@@ -6,7 +6,7 @@ groups:
         expr: |
           time() - container_last_seen{name="quasar_grafana"} > 10
             or
-          time() - container_last_seen{name="arcam_nginx"} > 10
+          time() - container_last_seen{name="quasar_nginx"} > 10
             or
           time() - container_last_seen{name="sce-ledsign"} > 10
             or

--- a/monitoring/prometheus/alert_rules.yml
+++ b/monitoring/prometheus/alert_rules.yml
@@ -1,6 +1,6 @@
 groups: 
   - name: alert_rules
-    interval: 1s
+    interval: 15s
     rules: 
       - alert: container_not_running
         expr: |

--- a/monitoring/prometheus/alert_rules.yml
+++ b/monitoring/prometheus/alert_rules.yml
@@ -1,0 +1,25 @@
+groups: 
+  - name: alert_rules
+    interval: 1s
+    rules: 
+      - alert: container_not_running
+        expr: |
+          time() - container_last_seen{name="quasar_grafana"} > 10
+            or
+          time() - container_last_seen{name="arcam_nginx"} > 10
+            or
+          time() - container_last_seen{name="sce-ledsign"} > 10
+            or
+          time() - container_last_seen{name="sce-printer"} > 10
+            or
+          time() - container_last_seen{name="quasar_influx"} > 10
+            or
+          time() - container_last_seen{name="quasar_cadvisor"} > 10
+            or
+          time() - container_last_seen{name="quasar_grafana"} > 10
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Container "{{ $labels.name }}" is not running
+          description: 'container "{{ $labels.name }}" has been down for more than {{ $value | printf "%.0f" }}'

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -8,3 +8,6 @@ scrape_configs:
   - job_name: 'led-sign'
     static_configs:
       - targets: ['led-sign:5000']
+
+rule_files:
+  - alert_rules.yml


### PR DESCRIPTION
Alerts have been added for each container made thus far to prometheus. 
<details>
<summary> How to Test </summary>
Run docker-compose up --build  <br>
Go to localhost/prometheus on your browser.  <br>
Go to the alerts tab and you should see this: <br>
<img width="398" alt="Screen Shot 2022-07-20 at 6 14 43 PM" src="https://user-images.githubusercontent.com/63530023/180108699-5258fc84-5fd7-4aee-93fc-ce1845d76649.png"> <br>
Go into your terminal and run this command docker stop <container_id>
Prometheus will show this:
<img width="353" alt="Screen Shot 2022-07-20 at 6 19 37 PM" src="https://user-images.githubusercontent.com/63530023/180109170-bff20ecd-e118-4cb0-bde2-57ae60fe609a.png"> <br>
Run docker start <container_id> in the terminal, and the problem will be resolved.
</details>


