### PR TITLE
Add tray empty snmp metric

### DIFF
--- a/collector/server.py
+++ b/collector/server.py
@@ -54,6 +54,7 @@ class SnmpOid(enum.Enum):
     PAGE_COUNT = ("page_count", "1.3.6.1.2.1.43.10.2.1.4.1.1")
     DOOR_STATUS = ("door_status", "1.3.6.1.2.1.43.18.1.1.2.1.12", True)
     TRAY_STATUS = ("tray_status", "1.3.6.1.2.1.43.18.1.1.2.1.9", True)
+    TRAY_EMPTY = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.13", True)
 
     def __init__(self, metric_name, metric_value, is_error=False):
         self.metric_name = metric_name

--- a/collector/server.py
+++ b/collector/server.py
@@ -52,8 +52,6 @@ class SnmpOid(enum.Enum):
     INK_LEVEL = ("ink_level", "1.3.6.1.2.1.43.11.1.1.9.1.1")
     INK_CAPACITY = ("ink_capacity", "1.3.6.1.2.1.43.11.1.1.8.1.1")
     PAGE_COUNT = ("page_count", "1.3.6.1.2.1.43.10.2.1.4.1.1")
-    DOOR_STATUS = ("door_status", "1.3.6.1.2.1.43.18.1.1.2.1.12", True)
-    TRAY_STATUS = ("tray_status", "1.3.6.1.2.1.43.18.1.1.2.1.9", True)
     TRAY_EMPTY = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.13", True)
 
     def __init__(self, metric_name, metric_value, is_error=False):


### PR DESCRIPTION
The closest snmp metric reference (slightly higher in the tree) is below

https://oidref.com/1.3.6.1.2.1.43.18.1.1.8

example of the metric being present is below
```
sce@poweredge-2950:~/monitoring$ snmpwalk -v 1 -c public 192.168.69.208 | grep "3.6.1.2.1.43.18.1.1.8.1.13"
iso.3.6.1.2.1.43.18.1.1.8.1.13 = STRING: "TRAY EMPTY"
```
