### PR TITLE
Add second tray empty metric

### DIFF
--- a/collector/server.py
+++ b/collector/server.py
@@ -53,6 +53,7 @@ class SnmpOid(enum.Enum):
     INK_CAPACITY = ("ink_capacity", "1.3.6.1.2.1.43.11.1.1.8.1.1")
     PAGE_COUNT = ("page_count", "1.3.6.1.2.1.43.10.2.1.4.1.1")
     TRAY_EMPTY = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.13", True)
+    TRAY_EMPTY = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.2", True)
 
     def __init__(self, metric_name, metric_value, is_error=False):
         self.metric_name = metric_name
@@ -76,10 +77,10 @@ def get_snmp_data(ip):
             ObjectType(ObjectIdentity(oid.metric_value)))
             )
             if errorIndication:
-                logging.error(f"Error: {errorIndication}")
+                logging.error(f"Error indication from {ip} for metric {oid.metric_value}: {errorIndication}")
                 device_unreachable.set(1)
             elif errorStatus:
-                logging.error(f"Error: {errorStatus.prettyPrint()}")
+                logging.error(f"Error status from {ip} for metric {oid.metric_value}: {errorStatus.prettyPrint()}")
             else:
                 for res in varBinds:
                     if oid.is_error:

--- a/collector/server.py
+++ b/collector/server.py
@@ -54,7 +54,10 @@ class SnmpOid(enum.Enum):
     PAGE_COUNT = ("page_count", "1.3.6.1.2.1.43.10.2.1.4.1.1")
     TRAY_EMPTY = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.13", True)
     # we observed each printer emitting a different SNMP OID for
-    # an empty paper tray, the below accounts for the second OID
+    # an empty paper tray, the below accounts for this second OID.
+    # the _2 at the end of this metric does imply that the printer has
+    # 2 trays. tray_empty_2 is an indication of the same exact issue
+    # as tray_empty: an empty paper tray.
     TRAY_EMPTY_2 = ("tray_empty_2", "1.3.6.1.2.1.43.18.1.1.8.1.2", True)
 
     def __init__(self, metric_name, metric_value, is_error=False):

--- a/collector/server.py
+++ b/collector/server.py
@@ -53,7 +53,9 @@ class SnmpOid(enum.Enum):
     INK_CAPACITY = ("ink_capacity", "1.3.6.1.2.1.43.11.1.1.8.1.1")
     PAGE_COUNT = ("page_count", "1.3.6.1.2.1.43.10.2.1.4.1.1")
     TRAY_EMPTY = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.13", True)
-    TRAY_EMPTY = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.2", True)
+    # we observed each printer emitting a different SNMP OID for
+    # an empty paper tray, the below accounts for the second OID
+    TRAY_EMPTY_2 = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.2", True)
 
     def __init__(self, metric_name, metric_value, is_error=False):
         self.metric_name = metric_name

--- a/collector/server.py
+++ b/collector/server.py
@@ -55,7 +55,7 @@ class SnmpOid(enum.Enum):
     TRAY_EMPTY = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.13", True)
     # we observed each printer emitting a different SNMP OID for
     # an empty paper tray, the below accounts for the second OID
-    TRAY_EMPTY_2 = ("tray_empty", "1.3.6.1.2.1.43.18.1.1.8.1.2", True)
+    TRAY_EMPTY_2 = ("tray_empty_2", "1.3.6.1.2.1.43.18.1.1.8.1.2", True)
 
     def __init__(self, metric_name, metric_value, is_error=False):
         self.metric_name = metric_name
@@ -70,6 +70,15 @@ def work(ip_list):
 
 def get_snmp_data(ip):
     for oid in SnmpOid:
+        # set the error to zero by default, this is because
+        # SNMP OIDs related to errors often dissappear when
+        # the associated issue that the metric refers to is
+        # no longer present (i.e. an empty tray now has
+        # paper). To avoid leaving an error metric as 1
+        # which would create a false positive, set the error
+        # as zero before reading anything.
+        if oid.is_error:
+            snmp_error.labels(name=oid.metric_name, ip=ip).set(0)
         with snmp_req_duration.time():
             errorIndication, errorStatus, errorIndex, varBinds = next(
             getCmd(SnmpEngine(),
@@ -81,15 +90,19 @@ def get_snmp_data(ip):
             if errorIndication:
                 logging.error(f"Error indication from {ip} for metric {oid.metric_value}: {errorIndication}")
                 device_unreachable.set(1)
-            elif errorStatus:
+                continue
+            if errorStatus:
                 logging.error(f"Error status from {ip} for metric {oid.metric_value}: {errorStatus.prettyPrint()}")
-            else:
-                for res in varBinds:
-                    if oid.is_error:
-                        snmp_error.labels(name=oid.metric_name, ip=ip).set(int(res[1] == 3))
-                        continue
-                    snmp_metric.labels(name=oid.metric_name, ip=ip).set(res[1])
-                    device_unreachable.set(0)
+                continue
+
+            device_unreachable.set(0)
+            if not varBinds:
+                continue
+            res = varBinds[0]
+            if oid.is_error:
+              snmp_error.labels(name=oid.metric_name, ip=ip).set(1)
+              continue
+            snmp_metric.labels(name=oid.metric_name, ip=ip).set(res[1])
 
 @app.get("/metrics")
 async def metrics():


### PR DESCRIPTION
the metrics are slightly different on each printer, the output is below

```sh
sce@poweredge-2950:~/Quasar$ snmpwalk -v 1 -c public 192.168.69.208 | grep "TRAY"
iso.3.6.1.2.1.43.18.1.1.8.1.13 = STRING: "TRAY EMPTY"
sce@poweredge-2950:~/Quasar$ snmpwalk -v 1 -c public 192.168.69.149 | grep "TRAY"
iso.3.6.1.2.1.43.18.1.1.8.1.2 = STRING: "TRAY EMPTY"
```

I dont know why this is, we can explore this later. for now we need monitoring on printers with empty paper