### PR TITLE
Set Prometheus metric to 0 if SNMP metric not found

### DIFF
--- a/collector/server.py
+++ b/collector/server.py
@@ -73,15 +73,6 @@ def work(ip_list):
 
 def get_snmp_data(ip):
     for oid in SnmpOid:
-        # set the error to zero by default, this is because
-        # SNMP OIDs related to errors often dissappear when
-        # the associated issue that the metric refers to is
-        # no longer present (i.e. an empty tray now has
-        # paper). To avoid leaving an error metric as 1
-        # which would create a false positive, set the error
-        # as zero before reading anything.
-        if oid.is_error:
-            snmp_error.labels(name=oid.metric_name, ip=ip).set(0)
         with snmp_req_duration.time():
             errorIndication, errorStatus, errorIndex, varBinds = next(
             getCmd(SnmpEngine(),
@@ -90,22 +81,30 @@ def get_snmp_data(ip):
             ContextData(),
             ObjectType(ObjectIdentity(oid.metric_value)))
             )
-            if errorIndication:
-                logging.error(f"Error indication from {ip} for metric {oid.metric_value}: {errorIndication}")
-                device_unreachable.set(1)
-                continue
-            if errorStatus:
-                logging.error(f"Error status from {ip} for metric {oid.metric_value}: {errorStatus.prettyPrint()}")
-                continue
-
-            device_unreachable.set(0)
-            if not varBinds:
-                continue
-            res = varBinds[0]
+        if errorIndication:
+            logging.error(f"Error indication from {ip} for metric {oid.metric_value}: {errorIndication}")
+            device_unreachable.set(1)
+            continue
+        if errorStatus:
+            logging.error(f"Error status from {ip} for metric {oid.metric_value}: {errorStatus.prettyPrint()}")
+            # SNMP OIDs related to errors often dissappear when
+            # the associated issue that the metric refers to is
+            # no longer present (i.e. an empty tray now has
+            # paper). To avoid leaving an error metric as 1
+            # which would create a false positive, set the metric
+            # to zero if the associated SNMP OID was not found
             if oid.is_error:
-              snmp_error.labels(name=oid.metric_name, ip=ip).set(1)
-              continue
-            snmp_metric.labels(name=oid.metric_name, ip=ip).set(res[1])
+                snmp_error.labels(name=oid.metric_name, ip=ip).set(0)
+            continue
+
+        device_unreachable.set(0)
+        if not varBinds:
+            continue
+        res = varBinds[0]
+        if oid.is_error:
+            snmp_error.labels(name=oid.metric_name, ip=ip).set(1)
+            continue
+        snmp_metric.labels(name=oid.metric_name, ip=ip).set(res[1])
 
 @app.get("/metrics")
 async def metrics():


### PR DESCRIPTION
resolve prometheus catching the error metric as zero, when it should be 1.

now, we only set the error metric to zero if its associated OID wasn't found in the SNMP query