### PR TITLE
Parsing config.json to read ips instead of args

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -10,4 +10,6 @@ COPY ./collector/server.py /app
 
 EXPOSE 5000
 
-ENTRYPOINT [ "python", "server.py" ]
+ENTRYPOINT [ "python", "server.py"]
+
+CMD [ "--config-file-path", "/tmp/config.json"]

--- a/collector/server.py
+++ b/collector/server.py
@@ -3,6 +3,7 @@ import argparse
 from threading import Thread
 import enum
 import logging
+import json
 
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -140,10 +141,18 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    ip_list = args.ips.split(',')
+    try:
+        with open("../config/config.json", "r") as f:
+            config = json.load(f)
+            left_ip = config["PRINTING"]["LEFT"]["IP"]
+            right_ip = config["PRINTING"]["RIGHT"]["IP"]
+            ip_list=[left_ip, right_ip]
 
-    thread = Thread(target = scrape_snmp, args=(ip_list,), daemon=True)
-    thread.start()
+            thread = Thread(target = scrape_snmp, args=(ip_list,), daemon=True)
+            thread.start()
+    except Exception as e:
+        logging.error(f"error opening config file: {e}")
+
     uvicorn.run(
         app, 
         host=args.host, 

--- a/collector/server.py
+++ b/collector/server.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     try:
-        with open("/config/config.json", "r") as f:
+        with open("/tmp/config.json", "r") as f:
             config = json.load(f)
             left_ip = config["PRINTING"]["LEFT"]["IP"]
             right_ip = config["PRINTING"]["RIGHT"]["IP"]

--- a/collector/server.py
+++ b/collector/server.py
@@ -148,6 +148,8 @@ if __name__ == "__main__":
             right_ip = config["PRINTING"]["RIGHT"]["IP"]
             ip_list=[left_ip, right_ip]
 
+            logging.info(f"connected to left printer ip: {left_ip}")
+            logging.info(f"connected to right printer ip: {right_ip}")   
             thread = Thread(target = scrape_snmp, args=(ip_list,), daemon=True)
             thread.start()
     except Exception as e:

--- a/collector/server.py
+++ b/collector/server.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     try:
-        with open("../config/config.json", "r") as f:
+        with open("/config/config.json", "r") as f:
             config = json.load(f)
             left_ip = config["PRINTING"]["LEFT"]["IP"]
             right_ip = config["PRINTING"]["RIGHT"]["IP"]

--- a/collector/server.py
+++ b/collector/server.py
@@ -116,7 +116,12 @@ async def metrics():
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("snmp coolness")
-
+    parser.add_argument(
+        "--config-file-path", 
+        required=True,
+        help="Path to config file that stores IPs",
+    )
+    
     parser.add_argument(
         "--ips",
         help="List of IP addresses of snmp agent (default: 192.168.69.208,192.168.69.149)",
@@ -142,7 +147,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     try:
-        with open("/tmp/config.json", "r") as f:
+        with open(args.config_file_path, "r") as f:
             config = json.load(f)
             left_ip = config["PRINTING"]["LEFT"]["IP"]
             right_ip = config["PRINTING"]["RIGHT"]["IP"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     build:
       context: .
       dockerfile: ./collector/Dockerfile
+
+    volumes:
+      - ./config/config.json:/tmp/config.json
 # we attach the print container to an external docker
 # network called "poweredge". we do this so a prometheus
 # container can pull metrics from the server over HTTP


### PR DESCRIPTION
- reading files with python, error-handling
- tested on sce-vpn by just running installing dependencies using ```pip install -r requirements.txt``` and running ```python3 server.py``` 

